### PR TITLE
Fix header to older version - remove title and subtitle, keep theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,6 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <div class="theme-controls">
                     <button 
                         id="theme-toggle" 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -103,30 +103,11 @@ header {
     max-width: 1200px;
     margin: 0 auto;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     padding: 0 1.5rem;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {


### PR DESCRIPTION
This PR reverts the header to the older version as requested in issue #3.

**Changes:**
- Removed "Course Materials Assistant" header title
- Removed subtitle "Ask questions about courses, instructors, and content"
- Kept theme toggle controls with all functionality intact
- Updated CSS to right-align header content
- Cleaned up unused CSS classes

**Result:**
The header now displays only the theme toggle controls in the top-right corner, providing a cleaner, minimal design while preserving all theme functionality.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)